### PR TITLE
Update pool id

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Steps needed for eligibility:
 
 1. Create an address on Cardano's [Preview Testnet](https://book.world.dev.cardano.org/environments.html#preview-testnet)
 2. Grab some tADA from the [faucet](https://faucet.preview.world.dev.cardano.org/basic-faucet)
-2. Delegate to the PJUNGLE Stake Pool using the following pool id: `pool1lu942x5chr8uc9zjzltkrm8m2q7raqyuhsw8xplcg0sn77r9jzt`  
+2. Delegate to the JUNGLE Stake Pool on Preview testnet using the following pool id: `pool1j3x329u0uxh9s9vjvsad9kx37tzal8gndz6ttxumcz4nw947djw`
 3. Wait a few seconds for the transaction to go through
 4. Use your base address to check for eligibility. If your delegation went through, then you should be eligible! 
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -84,7 +84,10 @@ end
 
 config :simple_drop, SimpleDrop.BlockfrostClient,
   project_id: System.get_env("BLOCKFROST_PROJECT_ID", nil),
-  base_url: System.get_env("BLOCKFROST_BASE_URL", "https://cardano-preview.blockfrost.io/api/v0/")
+  base_url:
+    System.get_env("BLOCKFROST_BASE_URL", "https://cardano-preview.blockfrost.io/api/v0/"),
+  pool_id:
+    System.get_env("JUNGLE_POOL_ID", "pool1j3x329u0uxh9s9vjvsad9kx37tzal8gndz6ttxumcz4nw947djw")
 
 config :simple_drop,
        SimpleDropWeb.Endpoint,

--- a/lib/simple_drop/blockfrost_client.ex
+++ b/lib/simple_drop/blockfrost_client.ex
@@ -30,7 +30,11 @@ defmodule SimpleDrop.BlockfrostClient do
 
   def delegators() do
     # Hardcoded to Preview Jungle
-    get("/pools/pool1lu942x5chr8uc9zjzltkrm8m2q7raqyuhsw8xplcg0sn77r9jzt/delegators")
+    get("/pools/#{pool_id()}/delegators")
+  end
+
+  defp pool_id do
+    Application.get_env(:simple_drop, SimpleDrop.BlockfrostClient)[:pool_id]
   end
 
   def base_url() do


### PR DESCRIPTION
Re-spin of the test networks required the recreation of the pool. Hence the new pool id.

It is now configurable via ENV.